### PR TITLE
Adding logic to use either hostname or fqdn fact

### DIFF
--- a/manifests/set_authorized_key.pp
+++ b/manifests/set_authorized_key.pp
@@ -36,8 +36,11 @@ define sshkeys::set_authorized_key (
       ensure => absent,
     }
   } else {
-    # Get the key
-    $results = query_facts("fqdn=\"${remote_node}\"", ["sshpubkey_${remote_username}"])
+    if $remote_node =~ /\./ {
+      $results = query_facts("fqdn=\"${remote_node}\"", ["sshpubkey_${remote_username}"])
+    } else {
+      $results = query_facts("hostname=\"${remote_node}\"", ["sshpubkey_${remote_username}"])
+    }
     $key = $results[$remote_node]["sshpubkey_${remote_username}"]
     if ($key !~ /^(ssh-...) ([^ ]*)/) {
       err("Can't parse key from ${remote_user}")


### PR DESCRIPTION
I've added some simple logic to determine whether the remote host is specified as a hostname or fqdn. This makes the PuppetDB lookup a bit more flexible and robust, so it works in Vagrant environments as well.
