### PR TITLE
Check for possible non-existing keys

### DIFF
--- a/manifests/set_authorized_key.pp
+++ b/manifests/set_authorized_key.pp
@@ -42,7 +42,7 @@ define sshkeys::set_authorized_key (
     } else {
       $results = query_facts("hostname=\"${remote_node}\"", ["sshpubkey_${remote_username}"])
     }
-    if $results[$remote_node] {
+    if has_key($results[$remote_node], "sshpubkey_${remote_username}") {
       $key = $results[$remote_node]["sshpubkey_${remote_username}"]
       if ($key !~ /^(ssh-...) ([^ ]*)/) {
         err("Can't parse key from ${remote_user}")
@@ -57,6 +57,8 @@ define sshkeys::set_authorized_key (
           options => $options ? { undef => undef, default => $options },
         }
       }
+    } else {
+      notify { "Public key from ${remote_user}@${remote_node} not available yet. Skipping": }
     }
   }
 }


### PR DESCRIPTION
This is a suggested fix for issue #3. It checks to see if a key was found in PuppetDB. If nothing was found it simply skips trying to create the authorized key. 
