### PR TITLE
Fix sshkey fact for usernames with dashes or dots

### DIFF
--- a/lib/facter/sshpubkey.rb
+++ b/lib/facter/sshpubkey.rb
@@ -1,7 +1,7 @@
 require 'etc'
 
 Etc.passwd do |pw|
-  user = pw.name
+  user = pw.name.gsub!(/[^a-zA-Z0-9_]/, '')
   homedir = pw.dir
   key = false
 


### PR DESCRIPTION
Without this, the facts cannot be used in puppet code as variable names may not contain these characters.
