### PR TITLE
Ensure public key file is write-able, and check for absent public key when private key is present.

### DIFF
--- a/manifests/create_key.pp
+++ b/manifests/create_key.pp
@@ -65,10 +65,24 @@ define sshkeys::create_key (
     $require3 = $require2
   }
 
+  exec { "test_keypair-${name}": 
+    command  => "/usr/bin/test -f \"${home_real}/.ssh/id_${ssh_keytype}.pub\"",
+    user     => $name,
+    onlyif   => "/usr/bin/test -f ${home_real}/.ssh/id_${ssh_keytype}",
+    require  => $require3, 
+  }
+
+  exec { "test_pubkey-${name}":
+    command => "/bin/echo 'test' > \"${home_real}/.ssh/id_${ssh_keytype}.pub\"",
+    user    => $name,
+    creates => "${home_real}/.ssh/id_${ssh_keytype}",
+    require => $require3,
+  }
+
   exec { "ssh_keygen-${name}":
     command => "/usr/bin/ssh-keygen -t ${ssh_keytype} -f \"${home_real}/.ssh/id_${ssh_keytype}\" -N '${passphrase}' -C '${name}@${::fqdn}'",
     user    => $name,
     creates => "${home_real}/.ssh/id_${ssh_keytype}",
-    require => $require3,
+    require => Exec["test_pubkey-${name}"],
   }
 }


### PR DESCRIPTION
I've added the test to ensure the public key file is write-able so that, if anyone decides to go ahead and make it immutable, the run will fail. This will avoid any risks of a mismatching keypair, should this case occur.

I also added a check for an absent public key file, when the private key file is present. Right now this will just show exec's output reporting failure. I'd hoped to somehow trigger a `warning` message, but couldn't think of any clean way to do so.
