### PR TITLE
Update documentation to use sshkeys::create_ssh_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Usage
 Create a SSH key for a user (this is optional):
 
 ```puppet
-sshkeys::create_key { 'root':
+sshkeys::create_ssh_key { 'root':
   ssh_keytype => 'dsa',
 }
 ```

--- a/manifests/create_ssh_key.pp
+++ b/manifests/create_ssh_key.pp
@@ -1,4 +1,4 @@
-# == Defined Type: sshkeys::create_key
+# == Defined Type: sshkeys::create_ssh_key
 #
 #   Creates an SSH key for a user
 #


### PR DESCRIPTION
It looks like the sshkeys::create_ssh_key define used to have a different name, and the documentation was not completely updated.