### PR TITLE
A little correction when hostname contains lower-case letters.

### DIFF
--- a/manifests/set_authorized_key.pp
+++ b/manifests/set_authorized_key.pp
@@ -30,7 +30,7 @@ define sshkeys::set_authorized_key (
   # Parse the name
   $parts = split($remote_user, '@')
   $remote_username = $parts[0]
-  $remote_node     = $parts[1]
+  $remote_node     = downcase($parts[1])
 
   $home = getvar("::home_${local_user}")
 


### PR DESCRIPTION
I know, that having a hostname with CAPITAL letters is generally a bed practice, but sometimes it happens. And usually software handle it gracefully, Puppet included. The only exception so far was this module. I send this trivial fix to help you to maintain compatibility with hostnames with capital letters.
