### PR TITLE
Add bit length option to create_ssh_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ sshkeys::create_ssh_key { 'root':
 }
 ```
 
+The default bit lengths are 2048 for rsa and 1024 for dsa.  To override the defaults, use the ssh_bitlength parameter.
+
 Once created, Facter will expose the public key via the fact `sshpubkey_root`.
 
 To allow `root@server1` to access `root@server2`:

--- a/manifests/create_ssh_key.pp
+++ b/manifests/create_ssh_key.pp
@@ -19,15 +19,44 @@
 #   [*passphrase*]
 #     Optional passphrase to set on the key.
 #
+#   [*bit_length*]
+#     Optional bit length for key.
+#     Defaults to 2048 for rsa and 1024 for dsa.
+#
 define sshkeys::create_ssh_key (
   $owner          = undef,
   $group          = undef,
   $create_ssh_dir = true,
   $ssh_keytype    = 'rsa',
-  $passphrase     = ''
+  $ssh_bitlength  = undef,
+  $passphrase     = '',
 ) {
 
+  validate_bool($create_ssh_dir)
+  validate_string($ssh_keytype)
+
   $homedir = getvar("::home_${name}")
+
+  # Set $bitlength to default if no value provided
+  $rsa_default = '2048'
+  $dsa_default = '1024'
+
+  if $ssh_bitlength {
+    $bitlength = $ssh_bitlength
+  }
+  else {
+    case $ssh_keytype {
+      'rsa': {
+        $bitlength = $rsa_default
+      }
+      'dsa': {
+        $bitlength = $dsa_default
+      }
+      default: {
+        fail('The sshkeys module currently supports only rsa or dsa default bit lengths')
+      }
+    }
+  }
 
   if $owner {
     $owner_real = $owner
@@ -54,10 +83,9 @@ define sshkeys::create_ssh_key (
   }
 
   exec { "ssh_keygen-${name}":
-    command => "/usr/bin/ssh-keygen -t ${ssh_keytype} -f '${homedir}/.ssh/id_${ssh_keytype}' -N '${passphrase}' -C '${name}@${::fqdn}'",
+    command => "/usr/bin/ssh-keygen -t ${ssh_keytype} -b ${bitlength} -f '${homedir}/.ssh/id_${ssh_keytype}' -N '${passphrase}' -C '${name}@${::fqdn}'",
     user    => $name,
     creates => "${homedir}/.ssh/id_${ssh_keytype}",
     require => $require,
   }
-
 }

--- a/spec/defines/create_ssh_key_spec.rb
+++ b/spec/defines/create_ssh_key_spec.rb
@@ -13,7 +13,7 @@ describe 'sshkeys::create_ssh_key' do
     let(:title) { 'jdoe' }
 
     it { should contain_file('/home/jdoe/.ssh').with(:owner => 'jdoe') }
-    it { should contain_exec('ssh_keygen-jdoe').with(:command => "/usr/bin/ssh-keygen -t rsa -f '/home/jdoe/.ssh/id_rsa' -N '' -C 'jdoe@example.com'") }
+    it { should contain_exec('ssh_keygen-jdoe').with(:command => "/usr/bin/ssh-keygen -t rsa -b 2048 -f '/home/jdoe/.ssh/id_rsa' -N '' -C 'jdoe@example.com'") }
 
   end
 
@@ -30,7 +30,7 @@ describe 'sshkeys::create_ssh_key' do
 
     it do
       should contain_exec('ssh_keygen-jdoe').with({
-        :command => "/usr/bin/ssh-keygen -t dsa -f '/home/jdoe/.ssh/id_dsa' -N 'foobar' -C 'jdoe@example.com'",
+        :command => "/usr/bin/ssh-keygen -t dsa -b 1024 -f '/home/jdoe/.ssh/id_dsa' -N 'foobar' -C 'jdoe@example.com'",
         :user    => 'jdoe',
         :creates => '/home/jdoe/.ssh/id_dsa',
       })


### PR DESCRIPTION
Add a new parameter to allow setting the bit length of the new key.