### PR TITLE
Check before creating ${homedir}/.ssh that is not already defined.

### DIFF
--- a/manifests/create_ssh_key.pp
+++ b/manifests/create_ssh_key.pp
@@ -70,11 +70,13 @@ define sshkeys::create_ssh_key (
   }
 
   if $create_ssh_dir {
-    file { "${homedir}/.ssh":
-      ensure => directory,
-      owner  => $owner_real,
-      group  => $group_real,
-      mode   => '0700',
+    if !defined(File["${homedir}/.ssh"]) {
+      file { "${homedir}/.ssh":
+        ensure => directory,
+        owner  => $owner_real,
+        group  => $group_real,
+        mode   => '0700',
+      }
     }
     $require = File["${homedir}/.ssh"]
   } else {


### PR DESCRIPTION
I need the module to manage ${homedir}/.ssh, but if a other module
already defined it, there is no need to fight or crash over it.
