### PR TITLE
Various fixes and additions

### DIFF
--- a/lib/facter/sshpubkey.rb
+++ b/lib/facter/sshpubkey.rb
@@ -20,7 +20,7 @@ if homedir_users != nil and homedir_users.size > 0
   homedir_users.each do |u|
     begin
       pw = Etc.getpwnam(u)
-      user = pw.name.gsub(/[^a-zA-Z0-9_]/, '')
+      user = pw.name
       homedir = pw.dir
       key = false
 
@@ -38,7 +38,7 @@ if homedir_users != nil and homedir_users.size > 0
   end
 else
   Etc.passwd do |pw|
-    user = pw.name.gsub(/[^a-zA-Z0-9_]/, '')
+    user = pw.name
     homedir = pw.dir
     key = false
 

--- a/manifests/create_ssh_key.pp
+++ b/manifests/create_ssh_key.pp
@@ -10,8 +10,14 @@
 #   [*group*]
 #     The group owner of the homedir.
 #
+#   [*ssh_dir*]
+#     Directory where the key will be created. Defaults to '~user/.ssh'.
+#     Also allows to create the user and the key in the same agent run
+#     (when the user was just created, the home dir fact is not available
+#     before the next run)
+#
 #   [*create_ssh_dir*]
-#     Whether to create /home/user/.ssh.
+#     Whether to create the directory.
 #
 #   [*ssh_keytype*]
 #     Either rsa or dsa.
@@ -26,65 +32,84 @@
 define sshkeys::create_ssh_key (
   $owner          = undef,
   $group          = undef,
+  $ssh_dir        = undef,
   $create_ssh_dir = true,
   $ssh_keytype    = 'rsa',
   $ssh_bitlength  = undef,
   $passphrase     = '',
+  $require        = undef,
 ) {
 
   validate_bool($create_ssh_dir)
   validate_string($ssh_keytype)
 
-  $homedir = getvar("::home_${name}")
-
-  # Set $bitlength to default if no value provided
-  $rsa_default = '2048'
-  $dsa_default = '1024'
-
-  if $ssh_bitlength {
-    $bitlength = $ssh_bitlength
+  if ($ssh_dir != undef) {
+    $dir = $ssh_dir
   } else {
-    case $ssh_keytype {
-      'rsa': {
-        $bitlength = $rsa_default
-      }
-      'dsa': {
-        $bitlength = $dsa_default
-      }
-      default: {
-        fail('The sshkeys module currently supports only rsa or dsa default bit lengths')
+    $homedir = getvar("::home_${name}")
+    if ($homedir == undef) {
+	  notify { "Cannot determine the home dir of user '${name}'. Skipping SSH key creation": }
+	  $dir = undef
+	} else {
+	  $dir = "${homedir}/.ssh"
+	}
+  }
+
+  if ($dir != undef) {  
+    # Set $bitlength to default if no value provided
+    $rsa_default = '2048'
+    $dsa_default = '1024'
+  
+    if $ssh_bitlength {
+      $bitlength = $ssh_bitlength
+    } else {
+      case $ssh_keytype {
+        'rsa': {
+          $bitlength = $rsa_default
+        }
+        'dsa': {
+          $bitlength = $dsa_default
+        }
+        default: {
+          fail('The sshkeys module currently supports only rsa or dsa default bit lengths')
+        }
       }
     }
-  }
-
-  if $owner {
-    $owner_real = $owner
-  } else {
-    $owner_real = $name
-  }
-
-  if $group {
-    $group_real = $group
-  } else {
-    $group_real = $name
-  }
-
-  if $create_ssh_dir {
-    file { "${homedir}/.ssh":
-      ensure => directory,
-      owner  => $owner_real,
-      group  => $group_real,
-      mode   => '0700',
+  
+    if $owner {
+      $owner_real = $owner
+    } else {
+      $owner_real = $name
     }
-    $require = File["${homedir}/.ssh"]
-  } else {
-    $require = undef
-  }
-
-  exec { "ssh_keygen-${name}":
-    command => "/usr/bin/ssh-keygen -t ${ssh_keytype} -b ${bitlength} -f '${homedir}/.ssh/id_${ssh_keytype}' -N '${passphrase}' -C '${name}@${::fqdn}'",
-    user    => $name,
-    creates => "${homedir}/.ssh/id_${ssh_keytype}",
-    require => $require,
+  
+    if $group {
+      $group_real = $group
+    } else {
+      $group_real = $name
+    }
+  
+    if $create_ssh_dir {
+      file { "${dir}":
+        ensure => directory,
+        owner  => $owner_real,
+        group  => $group_real,
+        mode   => '0700',
+		require => $require,
+      }
+	  if ($require == undef) {
+		$required = File["${dir}"]
+      } else {
+		$required = [ $require, File["${dir}"] ].flatten
+	  }
+    } else {
+      $required = $require
+    }
+  
+    exec { "ssh_keygen-${name}":
+      command => "/usr/bin/ssh-keygen -t ${ssh_keytype} -b ${bitlength} -f '${dir}/id_${ssh_keytype}' -N '${passphrase}' -C '${name}@${::fqdn}'",
+      user    => $name,
+      creates => "${dir}/id_${ssh_keytype}",
+      require => $required,
+    }
   }
 }

--- a/manifests/set_authorized_key.pp
+++ b/manifests/set_authorized_key.pp
@@ -33,48 +33,50 @@ define sshkeys::set_authorized_key (
   $remote_node     = downcase($parts[1])
 
   $home = getvar("::home_${local_user}")
-
-  # Figure out the target
-  if $target {
-    $target_real = $target
+  if ($home == undef) {
+    notify { "Cannot determine the home dir of user '${local_user}'. Skipping SSH authorized key registration": }
   } else {
-    $target_real = "${home}/.ssh/authorized_keys"
-  }
-
-  Ssh_authorized_key {
-    user   => $local_user,
-    target => $target_real,
-  }
-
-  if $ensure == 'absent' {
-    ssh_authorized_key { $name:
-      ensure => absent,
-    }
-  } else {
-    # Get the key
-    if $remote_node =~ /\./ {
-      $results = query_facts("fqdn=\"${remote_node}\"", ["sshpubkey_${remote_username}"])
+    # Figure out the target
+    if $target {
+      $target_real = $target
     } else {
-      $results = query_facts("hostname=\"${remote_node}\"", ["sshpubkey_${remote_username}"])
+      $target_real = "${home}/.ssh/authorized_keys"
     }
-    if is_hash($results) and has_key($results, $remote_node) {
-      $key = $results[$remote_node]["sshpubkey_${remote_username}"]
-      if ($key !~ /^(ssh-...) ([^ ]*)/) {
-        err("Can't parse key from ${remote_user}")
-        notify { "Can't parse key from ${remote_user}. Skipping": }
-      } else {
-        $keytype = $1
-        $modulus = $2
-        ssh_authorized_key { $name:
-          ensure  => $ensure,
-          type    => $keytype,
-          key     => $modulus,
-          options => $options,
-        }
+    
+    Ssh_authorized_key {
+      user   => $local_user,
+      target => $target_real,
+    }
+    
+    if $ensure == 'absent' {
+      ssh_authorized_key { $name:
+        ensure => absent,
       }
     } else {
-      notify { "Public key from ${remote_username}@${remote_node} (for local user ${local_user}) not available yet. Skipping": }
+      # Get the key
+      if $remote_node =~ /\./ {
+        $results = query_facts("fqdn=\"${remote_node}\"", ["sshpubkey_${remote_username}"])
+      } else {
+        $results = query_facts("hostname=\"${remote_node}\"", ["sshpubkey_${remote_username}"])
+      }
+      if is_hash($results) and has_key($results, $remote_node) {
+        $key = $results[$remote_node]["sshpubkey_${remote_username}"]
+        if ($key !~ /^(ssh-...) ([^ ]*)/) {
+          err("Can't parse key from ${remote_user}")
+          notify { "Can't parse key from ${remote_user}. Skipping": }
+        } else {
+          $keytype = $1
+          $modulus = $2
+          ssh_authorized_key { $name:
+            ensure  => $ensure,
+            type    => $keytype,
+            key     => $modulus,
+            options => $options,
+          }
+        }
+      } else {
+        notify { "Public key from ${remote_username}@${remote_node} (for local user ${local_user}) not available yet. Skipping": }
+      }
     }
   }
-
 }


### PR DESCRIPTION
# Suppress character filtering on user name when exporting public keys

Filter could be maintained, but dash ('-') char at least should be added to the authorized character list.

# Protection against non-existent user

Currently, in both functions, if the user does not exist or if the home dir cannot be determined, the data is written in '/.ssh'. Unfortunately, it happens also when the user was just created and the home is not exported yet. This causes, for instance, the first run to generate a key in /.ssh, and the subsequent run to create a new key in the right directory.

Fix: if the home dir cannot be determined, action is abandoned and a 'skipping' notice is generated.

# Add a new 'ssh_dir' optional parameter to 'create_ssh_key'

This parameter allows to generate the key in the same run as the user creation. It also allows to generate a key pair anywhere (knowing it wont be exported).

# Add a new 'require' optional parameter to 'create_ssh_key'

This parameter provides a way to enforce dependencies between the resources creating the user, the '.ssh' directory, and the key files. Needed as soon as we allow generating user and key in the same run.