### PR TITLE
Work around duplicate definition when adding new keys to a new target server

### DIFF
--- a/manifests/set_authorized_key.pp
+++ b/manifests/set_authorized_key.pp
@@ -48,7 +48,7 @@ define sshkeys::set_authorized_key (
 
   $home = getvar("::home_${local_user}")
   if ($home == undef) {
-    notify { "Cannot determine the home dir of user '${local_user}'. Skipping SSH authorized key registration": }
+    notify { "Cannot determine the home dir of user '${local_user}' for key from ${remote_username}@${remote_node}. Skipping SSH authorized key registration": }
   } else {
     # Figure out the target
     if $target {


### PR DESCRIPTION
Handles the edge case where you have the same source user on two different nodes adding keys to a new target server that hasn't been setup yet (doesn't have the target user configured yet).